### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "react-scripts": "5.0.1",
     "reactstrap": "^9.1.9",
     "sweetalert": "^2.1.2",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "dompurify": "^3.2.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/admin/product/EditProduct.js
+++ b/frontend/src/components/admin/product/EditProduct.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 import axios from "axios";
 import swal from "sweetalert";
+import DOMPurify from "dompurify";
 
 
 function EditProduct(props) {
@@ -243,7 +244,7 @@ function EditProduct(props) {
                            <div className="col-md-4 form-group mb-3">
                            <label>Kép</label>
                            <input type="file" name="image" onChange={handleImage}  className="form-control" />
-                           <img src={`http://127.0.0.1:8000/${productInput.image}`} width="50px" alt={productInput.name}/>
+                           <img src={`http://127.0.0.1:8000/${DOMPurify.sanitize(productInput.image)}`} width="50px" alt={productInput.name}/>
                            <small className="text-danger">{errorList.image}</small>
                            </div>
 


### PR DESCRIPTION
Potential fix for [https://github.com/szijartoferenc/pizza/security/code-scanning/1](https://github.com/szijartoferenc/pizza/security/code-scanning/1)

To fix the problem, we need to ensure that the `productInput.image` value is properly sanitized before being used to construct the image source URL. This can be done by using a library like `DOMPurify` to sanitize the input. 

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the file.
3. Use `DOMPurify` to sanitize the `productInput.image` value before using it in the image source URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
